### PR TITLE
Make sure bpm is correctly calculated from Beatsource

### DIFF
--- a/src/tagger/beatsource.rs
+++ b/src/tagger/beatsource.rs
@@ -101,7 +101,11 @@ impl BeatsourceTrack {
                 .trim()
                 .to_string()
             ),
-            bpm: self.bpm,
+            bpm: if self.bpm - self.bpm / 100 * 100 >= 50 {
+                self.bpm / 100
+            } else {
+                self.bpm / 100 +1
+            },
             genres: vec![self.genre.name],
             art: self.release.image.map(|i| i.dynamic_uri
                 .replace("{w}", &config.beatsource.art_resolution.to_string())


### PR DESCRIPTION
Beatsource delivers its BPM values as 5-digits, ie 12593. iTunes cannot read the 5-digit value, instead showing a blank field for BPM. This PR fixes this by calculating the value.