### PR TITLE
Feature: shift to multiselect in QuickTag view

### DIFF
--- a/client/src/scripts/onetagger.ts
+++ b/client/src/scripts/onetagger.ts
@@ -555,13 +555,17 @@ class OneTagger {
         });
     }
 
+    addQTTrack(track: QTTrack) {
+        this.quickTag.value.track.addTrack(new QTTrack(JSON.parse(JSON.stringify(track)), this.settings.value.quickTag));
+    }
+
     /// Add or remove a track to the multitrack
     toggleQTTrack(track: QTTrack) {
         if (this.quickTag.value.track.getTrack(track.path)) {
             this.quickTag.value.track.removeTrack(track);
             return;
         }
-        this.quickTag.value.track.addTrack(new QTTrack(JSON.parse(JSON.stringify(track)), this.settings.value.quickTag));
+        this.addQTTrack(track);
     }
 
     // Save quickTagTrack

--- a/client/src/views/QuickTag.vue
+++ b/client/src/views/QuickTag.vue
@@ -279,6 +279,24 @@ function trackClick(track: QTTrack, event: MouseEvent) {
         return;
     }
 
+    // Add range of tracks to list
+    if (event.shiftKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+
+        const currentIndex = tracks.value.findIndex(t => t.path == track.path);
+        const startIndex = Math.min(selectionCursor, currentIndex);
+        const endIndex = Math.max(selectionCursor, currentIndex);
+
+        for (let i = startIndex; i <= endIndex; i++) {
+            $1t.addQTTrack(tracks.value[i]);
+        }
+
+        selectionCursor = currentIndex;
+        return;
+    }
+
     // Prevent clicking on same track
     if ($1t.quickTag.value.track.isSelected(track)) return;
     selectionCursor = tracks.value.findIndex(t => t.path == track.path);

--- a/client/src/views/QuickTag.vue
+++ b/client/src/views/QuickTag.vue
@@ -279,11 +279,16 @@ function trackClick(track: QTTrack, event: MouseEvent) {
         return;
     }
 
-    // Add range of tracks to list
+    // Expand to add range of tracks to list
     if (event.shiftKey) {
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
+
+        // No existing selection to expand
+        if (selectionCursor === -1) {
+            return;
+        }
 
         const currentIndex = tracks.value.findIndex(t => t.path == track.path);
         const startIndex = Math.min(selectionCursor, currentIndex);


### PR DESCRIPTION
Basic implementation to add a range of tracks. Does not implement nuanced UX of platforms e.g. https://stackoverflow.com/a/16530782

It simply gets the previous selection index, and adds anything to the selection between that index and the current click index.

It does not act in combination with ctrlKey click behavior, ctrlKey takes precedence.

See https://github.com/Marekkon5/onetagger/issues/450 for original ask.

https://github.com/user-attachments/assets/5bd9fbe7-5c83-4759-a71a-c577f35eea65

In the video we use shift to expand the selection three times, then deselect three tracks with ctrl click, then expand the selection again. I also tested expanding 'up' but didn't include this in the video.


