### PR TITLE
Leading Comma for Genres

### DIFF
--- a/client/src/components/QuickTagTile.vue
+++ b/client/src/components/QuickTagTile.vue
@@ -155,7 +155,10 @@ function removeCustom(tag: CustomTagInfo) {
         return;
     }    
     // Note
-    track.value.setNote(track.value.getNote().split(",").filter((i) => i != tag.value).join(","));
+    let values = track.value.getNote().split(",")
+                .map(n => n.trim())
+                .filter(n => n && n != tag.value);
+    track.value.setNote(values.join(", "));  // Note the space after comma
 }
 
 

--- a/client/src/components/QuickTagTileThin.vue
+++ b/client/src/components/QuickTagTileThin.vue
@@ -103,7 +103,10 @@ function removeCustom(tag: CustomTagInfo) {
         return;
     }    
     // Note
-    track.value.setNote(track.value.getNote().split(",").filter((i) => i != tag.value).join(","));
+    let values = track.value.getNote().split(",")
+                .map(n => n.trim())
+                .filter(n => n && n != tag.value);
+    track.value.setNote(values.join(", "));  // Note the space after comma
 }
 
 

--- a/client/src/scripts/quicktag.ts
+++ b/client/src/scripts/quicktag.ts
@@ -325,13 +325,6 @@ class QTTrack implements QuickTagFile {
             .filter(g => g.length > 0);
     }
 
-    processGenreString(genreStr: string | undefined): string[] {
-        if (!genreStr) return [];
-        return genreStr.split(',')
-            .map(g => g.trim())
-            .filter(g => g.length > 0);
-    }
-
     // Check if genre was changed
     isGenreChanged(): boolean {
         // Process both arrays for consistent comparison

--- a/client/src/scripts/quicktag.ts
+++ b/client/src/scripts/quicktag.ts
@@ -507,12 +507,16 @@ class QTTrack implements QuickTagFile {
         if (this.originalNote != this.note) {
             let field = this.removeAbstractions(this.settings.noteTag.tag.byFormat(this.format));
             // Remove original note from tags, add new one
-            let original = (this.originalNote??'').split(',');
+            let original = (this.originalNote??'').split(',').map(n => n.trim()).filter(n => n);
             let value = (this.tags[field]??[]).filter(t => !original.includes(t));
+            
+            // Split note by comma, trim each part, and filter out empty strings
+            let noteValues = (this.note??'').split(',').map(n => n.trim()).filter(n => n);
+            
             changes.push({
                 type: 'raw',
                 tag: field,
-                value: value.concat((this.note??'').split(','))
+                value: value.concat(noteValues)
             })
         }
         

--- a/client/src/scripts/quicktag.ts
+++ b/client/src/scripts/quicktag.ts
@@ -3,7 +3,7 @@ import { QuickTagSettings } from "./settings";
 import { FrameName, Keybind } from "./utils";
 import { get1t } from "./onetagger";
 
-class QuickTag {
+class QuickTag { 
     tracks: QTTrack[] = [];
     track: QTMultiTrack = new QTMultiTrack();
     failed: QuickTagFailed[] = [];
@@ -191,7 +191,7 @@ class QTMultiTrack {
     /// Set note on all tracks
     setNote(note: string) {
         for (let i=0; i<this.tracks.length; i++) {
-            this.tracks[i].note = note;
+            this.tracks[i].setNote(note); // Use the sanitizing setNote method
         }
     }
 
@@ -296,7 +296,7 @@ class QTTrack implements QuickTagFile {
         // Data from backend
         Object.assign(this, data);
         this.settings = settings;
-
+        this.genres = this.processGenreArray(this.genres);
         this.mood = this.getMood();
         this.energy = this.getEnergy();
         this.note = this.getNote();
@@ -312,6 +312,49 @@ class QTTrack implements QuickTagFile {
         }
     }
 
+    // Format genres for display
+    formatGenresString(genres: string[]): string {
+        // Filter out any empty strings, then join with comma + space
+        return this.processGenreArray(genres).join(', ');
+    }    
+    
+    // Process genres
+    processGenreArray(genres: string[]): string[] {
+        return genres
+            .map(g => g.trim())
+            .filter(g => g.length > 0);
+    }
+
+    processGenreString(genreStr: string | undefined): string[] {
+        if (!genreStr) return [];
+        return genreStr.split(',')
+            .map(g => g.trim())
+            .filter(g => g.length > 0);
+    }
+
+    // Check if genre was changed
+    isGenreChanged(): boolean {
+        // Process both arrays for consistent comparison
+        const currentGenres = [...this.genres]
+            .map(g => g.trim())
+            .filter(g => g.length > 0)
+            .sort()
+            .join(',');
+        const originalGenres = [...this.originalGenres]
+            .map(g => g.trim())
+            .filter(g => g.length > 0)
+            .sort()
+            .join(',');
+        return currentGenres !== originalGenres;
+    }
+
+    // Process note string
+    processNoteString(noteStr: string | undefined): string[] {
+        if (!noteStr) return [];
+        return noteStr.split(',')
+            .map(n => n.trim())
+            .filter(n => n.length > 0);
+    }
 
     // Remove field name abstractions
     removeAbstractions(input: string): string {
@@ -329,19 +372,23 @@ class QTTrack implements QuickTagFile {
             return this.note;
         }
         let field = this.removeAbstractions(this.settings.noteTag.tag.byFormat(this.format));
-        let note = this.tags[field]??[];
+        let noteValues = this.tags[field] ?? [];
+        
         // Remove custom tags from note
         for (let custom of this.settings.custom) {
             if (custom.tag.byFormat(this.format) == field) {
-                note = note.filter(v => !custom.values.map(i => i.val).includes(v));
+                noteValues = noteValues.filter(v => !custom.values.map(i => i.val).includes(v));
             }
         }
-        return note.join(',');
+        
+        // Process and join the note values
+        return this.processNoteString(noteValues.join(',')).join(',');
     }
 
     // Update note field
     setNote(note: string) {
-        this.note = note;
+        const processedParts = this.processNoteString(note);
+        this.note = processedParts.join(',');
     }
 
     // Get mood tag value
@@ -441,9 +488,8 @@ class QTTrack implements QuickTagFile {
         // Add note tag
         // out = out.concat(this.note.split(',').filter(v => !out.includes(v) && v));
         i = 0;
-        for (let value of this.note.split(',')) {
-            if (value.trim())
-                out.push({value, type: 'note', index: i});
+        for (let value of this.processNoteString(this.note)) {
+            out.push({value: value, type: 'note', index: i});
             i += 1;
         }
         return out;
@@ -478,27 +524,36 @@ class QTTrack implements QuickTagFile {
             }
         }
         // Genre change
-        if (this.genres.join('') != this.originalGenres.join('')) {
+        if (this.isGenreChanged()) {
             // Subgenre custom tag
             if (this.settings.subgenreTag) {
-
-                let subgenres = this.genres.filter((genre) => this.settings.genres.find((g) => g.subgenres.includes(genre)));
-                let genres = this.genres.filter((g) => !subgenres.includes(g));
-
+                let subgenres = this.processGenreArray(
+                    this.genres.filter((genre) => 
+                        this.settings.genres.find((g) => g.subgenres.includes(genre))
+                    )
+                );
+                
+                let genres = this.processGenreArray(
+                    this.genres.filter((g) => !subgenres.includes(g))
+                );
+                
                 changes.push({
                     type: 'raw',
                     tag: this.settings.subgenreTag.byFormat(this.format),
                     value: subgenres
                 });
+                
                 changes.push({
                     type: 'genre',
                     value: genres
                 });
-
             } else {
+                // Process the genres array to remove empty strings
+                const cleanGenres = this.processGenreArray(this.genres);
+                
                 changes.push({
                     type: 'genre',
-                    value: this.genres
+                    value: cleanGenres
                 });
             }
         }
@@ -506,18 +561,21 @@ class QTTrack implements QuickTagFile {
         // Note change
         if (this.originalNote != this.note) {
             let field = this.removeAbstractions(this.settings.noteTag.tag.byFormat(this.format));
-            // Remove original note from tags, add new one
-            let original = (this.originalNote??'').split(',').map(n => n.trim()).filter(n => n);
-            let value = (this.tags[field]??[]).filter(t => !original.includes(t));
             
-            // Split note by comma, trim each part, and filter out empty strings
-            let noteValues = (this.note??'').split(',').map(n => n.trim()).filter(n => n);
+            // Process original note consistently
+            let original = this.processNoteString(this.originalNote);
+            
+            // Filter out original note values from existing tags
+            let value = (this.tags[field] ?? []).filter(t => !original.includes(t));
+            
+            // Process new note consistently
+            let noteValues = this.processNoteString(this.note);
             
             changes.push({
                 type: 'raw',
                 tag: field,
                 value: value.concat(noteValues)
-            })
+            });
         }
         
         // Custom tags

--- a/client/src/scripts/quicktag.ts
+++ b/client/src/scripts/quicktag.ts
@@ -310,13 +310,7 @@ class QTTrack implements QuickTagFile {
             this.originalGenres.push(...subgenres.filter(g => !this.genres.includes(g)));
             this.genres.push(...subgenres.filter(g => !this.genres.includes(g)));
         }
-    }
-
-    // Format genres for display
-    formatGenresString(genres: string[]): string {
-        // Filter out any empty strings, then join with comma + space
-        return this.processGenreArray(genres).join(', ');
-    }    
+    } 
     
     // Process genres
     processGenreArray(genres: string[]): string[] {


### PR DESCRIPTION
## Issue Fixed
The PR addresses a bug in note field processing where:

1. Empty note fields were incorrectly processed - `split(',')` on an empty string created an array with one empty string element
2. This empty string was being added to metadata as a legitimate tag value

[Fixes #447](https://github.com/Marekkon5/onetagger/issues/447) - Prevents empty attributes from appearing in tags panel and being saved


## Changes Made

```diff
- let note = this.tags[field]??[];
+ let noteValues = this.tags[field] ?? [];
  
- return note.join(',');
+ return this.processNoteString(noteValues.join(',')).join(',');

- for (let value of this.note.split(',')) {
-   if (value.trim())
-     out.push({value, type: 'note', index: I});
+ for (let value of this.processNoteString(this.note)) {
+   out.push({value: value, type: 'note', index: I});
```

## New Helper Methods Added

```javascript
// Process note string
processNoteString(noteStr: string | undefined): string[] {
    if (!noteStr) return [];
    return noteStr.split(',')
        .map(n => n.trim())
        .filter(n => n.length > 0);
}

// Similar method for genres
processGenreArray(genres: string[]): string[] {
    return genres
        .map(g => g.trim())
        .filter(g => g.length > 0);
}
```

These changes ensure empty values are properly filtered out when processing both note and genre fields, preventing unwanted empty tags.