### PR TITLE
Use wss:// when client is served over HTTPS

### DIFF
--- a/client/src/scripts/utils.ts
+++ b/client/src/scripts/utils.ts
@@ -1,6 +1,7 @@
 // Returns the WebSocket server URL
 function wsUrl(): string {
-    return import.meta.env.DEV ? `ws://${window.location.hostname}:36913/ws` : `ws://${window.location.host}/ws`;
+    const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    return import.meta.env.DEV ? `${scheme}://${window.location.hostname}:36913/ws` : `${scheme}://${window.location.host}/ws`;
 }
 
 // Returns the HTTP server URL


### PR DESCRIPTION
The Vue client hardcodes `ws://` for its websocket URL, which causes mixed-content failures when the UI is served behind an HTTPS reverse proxy. Pick the scheme from `window.location.protocol` so the same build works behind both HTTP and HTTPS proxies.

One line change in `client/src/scripts/utils.ts`.

Refs the websocket-over-HTTPS issue from #111.

## Test plan
- [ ] Serve the UI over plain HTTP — websocket connects via `ws://` (unchanged)
- [ ] Serve the UI behind an HTTPS reverse proxy — websocket connects via `wss://`